### PR TITLE
Fix typo in footer

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -8,7 +8,7 @@
       <li><a href="https://playbook.cio.gov/">U.S. Digital Services Playbook</a></li>
       <li><a href="https://playbook.cio.gov/designstandards/">U.S. Web Design Standards</a></li>
       <li><a href="https://pages.18f.gov/accessibility/pagetitles/">Accessibility Guide</a></li>
-      <li><a href="https://github.com/department-of-veterans-affairs/roadrunner">Contribute to GitHub</a></li>
+      <li><a href="https://github.com/department-of-veterans-affairs/roadrunner">Contribute on GitHub</a></li>
     </ul>
     </section>
     


### PR DESCRIPTION
Small typo. The link goes to the Roadrunner page to contribute `on` GitHub, not `to` GitHub.
