### PR TITLE
Sorting tabbed navigation in desired order. closes #89

### DIFF
--- a/_includes/tabbed-nav.html
+++ b/_includes/tabbed-nav.html
@@ -1,4 +1,5 @@
-{% for page in site.pages %}
+{% assign pages = site.pages | sort: 'order' %}
+{% for page in pages %}
   {% if page.title %}
     <li><a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a></li>
   {% endif %}

--- a/content/index.md
+++ b/content/index.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
-title:  "Content Post"
+title:  "Content"
+order: 2
 ---
 
 #Vets.gov Content Style Guide

--- a/design/index.md
+++ b/design/index.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
-title:  "Design Post"
+title:  "Design"
+order: 1
 ---
 
 # Style Guide

--- a/feedback/index.markdown
+++ b/feedback/index.markdown
@@ -1,6 +1,7 @@
 ---
 layout: guide
-title:  "Feedback Post"
+title:  "Feedback"
+order: 3
 ---
 
 Feedback post


### PR DESCRIPTION
Adds order property to YAML that's used to sort each element in the nav.

modified:   _includes/tabbed-nav.html
modified:   content/index.md
modified:   design/index.md
modified:   feedback/index.markdown
