### PR TITLE
adding link to live site in readme and light editing of overview section for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 #### Overview
 
-A repository that will serve as sample app(s) and guidelines for Digital Service team application development. It will be a series of modular internal products that serves as a styleguide with specifications for content, design, engineering envrionment, automated testing and basic documentation. 
+Sample app(s) and guidelines for Digital Service team application development. A series of modular internal products that serves as a styleguide with specifications for content, design, engineering envrionment, automated testing, and basic documentation. 
 
 Primary customers are the Digital Service Team and our approved partners (in-house OIT designers and developers and/or contractors) to ramp up quickly and successfully design, build, and incorporate their apps into existing projects. 
+
+[View the site](http://department-of-veterans-affairs.github.io/roadrunner/)
 
 #### Purpose
 


### PR DESCRIPTION
I thought it would be useful to add a link to the live site (in Github pages) so that audiences can read the content before cloning the repository and hosting it locally.
